### PR TITLE
TEOC 2.0 - simple auth provisioning url update

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -222,7 +222,7 @@
             "sku": "F1",
             "serverFarmsName": "[format('{0}simpleAuth', variables('baseResourceName'))]",
             "webAppName": "[format('{0}simpleAuth', variables('baseResourceName'))]",
-            "simpleAuthPackageUri": "https://github.com/OfficeDev/TeamsFx/releases/download/simpleauth@0.1.0/Microsoft.TeamsFx.SimpleAuth_0.1.0.zip"
+            "simpleAuthPackageUri": "https://github.com/OfficeDev/TeamsFx/releases/download/simpleauth%400.1.2/Microsoft.TeamsFx.SimpleAuth_0.1.2.zip"
           },
           "resources": [
             {

--- a/Deployment/azuredeploygcch.json
+++ b/Deployment/azuredeploygcch.json
@@ -222,7 +222,7 @@
               "sku": "F1",
               "serverFarmsName": "[format('{0}simpleAuth', variables('baseResourceName'))]",
               "webAppName": "[format('{0}simpleAuth', variables('baseResourceName'))]",
-              "simpleAuthPackageUri": "https://github.com/OfficeDev/TeamsFx/releases/download/simpleauth@0.1.0/Microsoft.TeamsFx.SimpleAuth_0.1.0.zip"
+              "simpleAuthPackageUri": "https://github.com/OfficeDev/TeamsFx/releases/download/simpleauth%400.1.2/Microsoft.TeamsFx.SimpleAuth_0.1.2.zip"
             },
             "resources": [
               {


### PR DESCRIPTION
This PR has the updated URL for simpleAuthPackageUri to fix the provisioning error due to outdated package.